### PR TITLE
Added listen and accept permissions to port 8080

### DIFF
--- a/conf/mulgara-rmi.policy
+++ b/conf/mulgara-rmi.policy
@@ -23,7 +23,7 @@ grant
   permission java.net.SocketPermission "*:80", "listen,accept,connect,resolve";
   permission java.net.SocketPermission "*:443", "connect,resolve";
   permission java.net.SocketPermission "*:1099", "connect,resolve";
-  permission java.net.SocketPermission "*:8080", "connect,resolve";
+  permission java.net.SocketPermission "*:8080", "listen,accept,connect,resolve";
   permission java.net.SocketPermission "*:1024-", "accept,connect,resolve";
   permission java.net.SocketPermission "224.0.0.251", "connect,accept,resolve";
   permission java.security.SecurityPermission "getPolicy";


### PR DESCRIPTION
Minor change to rmi policies we needed to make locally because of permission problems after some java updates, which may be generally applicable.  This wasn't related to the jetty 8 upgrade.
