### PR TITLE
Fixed unicode chars in javadoc

### DIFF
--- a/src/jar/query/java/org/mulgara/query/rdf/LiteralImpl.java
+++ b/src/jar/query/java/org/mulgara/query/rdf/LiteralImpl.java
@@ -50,11 +50,11 @@ import org.mulgara.query.Value;
  * longer represents the string, but rather the encoded data. This is the format
  * returned from the ARP parser.
  *
- * For instance, the character Ž (e acute) has a unicode value of 0xE9, and a
+ * For instance, the character Ã© (e acute) has a unicode value of 0xE9, and a
  * UTF-8 encoding of [0xC3, 0xA9]. The literal string used to represent this character
  * has two characters in it (representing the 2 bytes from the UTF-8 encoding),
- * specifically Ì (Latin capital letter A with tilde, unicode value 0xC3)
- * and © (copyright sign, unicode value 0xA9). This is despite the fact that a Java
+ * specifically Ãƒ (Latin capital letter A with tilde, unicode value 0xC3)
+ * and Â© (copyright sign, unicode value 0xA9). This is despite the fact that a Java
  * string can represent e-acute with a single character.
  * 
  * Previously, this class accepted normal Java strings, and would escape them


### PR DESCRIPTION
I had trouble building the project due to these chars.
